### PR TITLE
[ADD] aad identiry

### DIFF
--- a/odoo/templates/_helpers.tpl
+++ b/odoo/templates/_helpers.tpl
@@ -48,6 +48,7 @@ Selector labels
 {{- define "odoo.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "odoo.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+aadpodidbinding: odoo
 {{- end }}
 
 {{/*


### PR DESCRIPTION
* Purpose
In order to be able to authenticate for blob storage , we have a pod identity.
for this purpose we need to add the label on pods