### PR TITLE
feat: odyssey add certificate verification

### DIFF
--- a/odyssey/Chart.yaml
+++ b/odyssey/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: Odyssey chart
 name: odyssey
-version: 0.1.25
+version: 0.1.26

--- a/odyssey/values.yaml
+++ b/odyssey/values.yaml
@@ -25,6 +25,16 @@ certificate:
 metrics:
   scrapeInterval: 15s
 
+livenessProbe:
+    exec:
+      command:
+      - /bin/sh
+      - -c
+      - "openssl x509 -enddate -noout < $CERTFILE > /tmp/TLSCURRENTENDDATE && if cmp -s /tmp/TLSCURRENTENDDATE /tmp/TLSENDDATE; then exit 0 ; else exit 1; fi"
+    initialDelaySeconds: 15
+    periodSeconds: 60
+    failureThreshold: 1
+
 
 # extra volumes for deployment
 volumes: []
@@ -32,9 +42,9 @@ volumes: []
 volumeMounts: []
 
 image:
-  repository: ghcr.io/camptocamp/odyssey
-  tag: latest
-  pullPolicy: Always
+  repository: ghcr.io/camptocamp/docker-odyssey
+  tag: 1.5.0
+  pullPolicy: IfNotPresent
 
 additionalAnnotations: {}
 additionalLabels: {}


### PR DESCRIPTION
* Purpose
With the image 1.5, a file TLSENDDATE with the end date of the current certificate is store in /tmp , it is create at startup.

The liveness will check this file with a current end date of the certificate, if cert manager changed the cert file, test will failed and pod will be restarted