### PR TITLE
feat: kwkhtmltopdf: no storage cleaning

### DIFF
--- a/kwkhtmltopdf/Chart.yaml
+++ b/kwkhtmltopdf/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: kwkhtmltopdf 
 description: A Helm chart to deploy  kwkhtmltopdf on Camptocamp own platform
 type: application
-version: 0.1.0
+version: 0.1.5

--- a/kwkhtmltopdf/templates/config-kwkhtmltopdf.yaml
+++ b/kwkhtmltopdf/templates/config-kwkhtmltopdf.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kwkhtmltopdf-config
+data:
+  {{- if .Values.no_storage_cleaning }}
+  NO_STORAGE_CLEANING: {{ .Values.no_storage_cleaning | default "True" | quote }}
+  {{- end }}

--- a/kwkhtmltopdf/templates/deployment.yaml
+++ b/kwkhtmltopdf/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
         {{- with .Values.additionalAnnotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
+        config-hash-kwkhtmltopdf: {{ include (print $.Template.BasePath "/config-kwkhtmltopdf.yaml") $ | sha256sum | trunc 63 }}
 
     spec:
       containers:
@@ -35,6 +36,9 @@ spec:
           livenessProbe:
             tcpSocket:
               port: 8080
+          envFrom:
+            - configMapRef:
+                name: kwkhtmltopdf-config
           volumeMounts:
             {{- toYaml .Values.volumeMounts | nindent 12 }}
           resources:

--- a/kwkhtmltopdf/values.yaml
+++ b/kwkhtmltopdf/values.yaml
@@ -30,7 +30,7 @@ affinity: {}
 
 additionalLabels: {}
   # aadpodidbinding: some-identity
-
+#no_storage_cleaning: true
 volumeMounts:
   - name: kwkhtmltopdftmp
     mountPath: /tmp


### PR DESCRIPTION
* Purpose
On dev, sometime we need to keep html file send by odoo to debug repo, in order to have the same image, I have create a new kwkhtmltopdf version to handle this