### PR TITLE
[FIX] odoo: 2 cron workers in hybrid modes

### DIFF
--- a/odoo/Chart.yaml
+++ b/odoo/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: odoo
 description: A Helm chart to deploy Odoo on CampToCamp own platform
 type: application
-version: 5.3.0
+version: 5.3.1

--- a/odoo/templates/_config_odoo_helpers.tpl
+++ b/odoo/templates/_config_odoo_helpers.tpl
@@ -50,7 +50,7 @@ data:
   KWKHTMLTOPDF_SERVER_URL: {{ .Values.odoo.kwkhtmltopdf_server_url | default "http://kwkhtmltopdf.bs-kwkhtmltopdf01250:8080" }}
   PGCLIENTENCODING: UTF8
   {{- if eq .pod_type "cron" -}}
-    {{- include "odoo.component-limits" (dict "compo" .Values.odoo.cron "default_max_conn" 5 "default_max_cron" "1") | nindent 2 -}}
+    {{- include "odoo.component-limits" (dict "compo" .Values.odoo.cron "default_max_conn" 5 "default_max_cron" "2") | nindent 2 -}}
   {{- else if eq .pod_type "thread" }}
     {{- include "odoo.component-limits" (dict "compo" .Values.odoo "default_max_conn" 20 "default_max_cron" "0") | nindent 2 -}}
   {{- else if eq .pod_type "queuejob" }}

--- a/odoo/values.yaml
+++ b/odoo/values.yaml
@@ -317,7 +317,7 @@ odoo:
       # memory_hard: 2097154
       # workers: 1
     limits:
-      max_cron: 1
+      max_cron: 2
     override_resources: {}
       # cpu: 5
       # memory: 8Gi


### PR DESCRIPTION
when running in worker mode, we would have 1 cron worker per replica, so typically 2. With the new hybrid mode we currenly default to 1 cron worker. This is a problem because in case of a cron that times out, the worker will keep trying to run this one and never process the remaining crons, whereas with 2 cron workers, while one of the workers is trying to process the too big cron (and fail) the second worker is able to work on the following ones