### PR TITLE
feat: create Odoo version label from odoo.odoo_version

### DIFF
--- a/odoo/templates/_deployment_helpers.tpl
+++ b/odoo/templates/_deployment_helpers.tpl
@@ -56,6 +56,9 @@ spec:
         app.kubernetes.io/component: "odoo-{{ .pod_type }}"
         release: "{{ .Release.Name }}"
         {{- include "odoo.selectorLabels" . | nindent 8 }}
+        {{- if .Values.odoo.odoo_version }}
+        odoo-version: {{ .Values.odoo.odoo_version | quote }}
+        {{- end }}
         {{- with .Values.additionalLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/odoo/templates/deployment.yaml
+++ b/odoo/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
       labels:
         {{- include "odoo.labels" $ | nindent 8 }}
         {{- include "odoo.selectorLabels" . | nindent 8 }}
+        {{- if .Values.odoo.odoo_version }}
+        odoo-version: {{ .Values.odoo.odoo_version | quote }}
+        {{- end }}
         {{- with .Values.additionalLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
Before this fix, the Odoo version is declared twice:
- odoo.odoo_version
- and additionalLabels.odoo-version

It's error-prone.
Better use only one.