### PR TITLE
feat: clean-up  in deployment.yaml and _deployment_helpers.tpl

### DIFF
--- a/odoo/templates/_deployment_helpers.tpl
+++ b/odoo/templates/_deployment_helpers.tpl
@@ -26,7 +26,7 @@ kind: Deployment
 metadata:
   name: {{ include "odoo.name" . }}-{{ .pod_type }}
   labels:
-    {{- include "odoo.labels" . | nindent 4 }}
+    {{- include "odoo.labels" $ | nindent 4 }}
 spec:
   replicas: {{ include "odoo.deployment.replicas" . }}
   strategy:
@@ -55,7 +55,6 @@ spec:
         app: {{ template "odoo.name" . }}
         app.kubernetes.io/component: "odoo-{{ .pod_type }}"
         release: "{{ .Release.Name }}"
-        {{- include "odoo.selectorLabels" . | nindent 8 }}
         {{- if .Values.odoo.odoo_version }}
         odoo-version: {{ .Values.odoo.odoo_version | quote }}
         {{- end }}
@@ -140,7 +139,7 @@ spec:
             - name: ODOO_MAX_HTTP_THREADS
               value: "True"
             {{- end }}
-          {{- include "odoo.common-environment" . | nindent 12 }}
+            {{- include "odoo.common-environment" . | nindent 12 }}
           envFrom:
             - configMapRef:
                 name: odoo-config{{- include "odoo-cs-suffix" . }}-{{ .pod_type }}
@@ -155,7 +154,7 @@ spec:
           {{- with .Values.odoo.livenessProbe }}
           livenessProbe:
               {{- toYaml . | nindent 14 }}
-           {{- end }}
+          {{- end }}
           {{- with .Values.odoo.readinessProbe }}
           readinessProbe:
               {{- toYaml . | nindent 14 }}
@@ -163,7 +162,7 @@ spec:
           {{- with .Values.odoo.startupProbe }}
           startupProbe:
               {{- toYaml . | nindent 14 }}
-           {{- end }}
+          {{- end }}
           {{- with .Values.volumeMounts }}
           {{- if .odoo }}
           volumeMounts:
@@ -173,11 +172,11 @@ spec:
           resources:
           {{ if eq .pod_type "cron" }}
             {{- include "odoo.physical-resources-cron" . | nindent 12 }}
-          {{ else if eq .pod_type "thread" }}
+          {{- else if eq .pod_type "thread" }}
             {{- include "odoo.physical-resources-thread" . | nindent 12 }}
-          {{ else }}
+          {{- else }}
             {{- include "odoo.physical-resources-worker" . | nindent 12 }}
-          {{ end }}
+          {{- end }}
         - name: nginx
           image: "{{ .Values.image.nginx.repository }}:{{ .Values.image.nginx.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/odoo/templates/deployment.yaml
+++ b/odoo/templates/deployment.yaml
@@ -2,9 +2,9 @@
 {{ if eq .Values.odoo.mode "hybrid" }}
 {{- include "odoo.deployment" (merge (. | deepCopy) (dict "pod_type" "thread")) }}
 {{- include "odoo.deployment" (merge (. | deepCopy) (dict "pod_type" "cron")) }}
-{{ else if eq .Values.odoo.mode "workers" }}
+{{- else if eq .Values.odoo.mode "workers" }}
 {{- include "odoo.deployment" (merge (. | deepCopy) (dict "pod_type" "worker")) }}
-{{ end }}
+{{- end }}
 {{ if .Values.odoo.queuejob.enabled }}
 ---
 apiVersion: apps/v1
@@ -38,15 +38,14 @@ spec:
         {{- end }}
       labels:
         {{- include "odoo.labels" $ | nindent 8 }}
-        {{- include "odoo.selectorLabels" . | nindent 8 }}
+        queuejob: "true"
+        app.kubernetes.io/component: "odoo-queue"
         {{- if .Values.odoo.odoo_version }}
         odoo-version: {{ .Values.odoo.odoo_version | quote }}
         {{- end }}
         {{- with .Values.additionalLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-        queuejob: "true"
-        app.kubernetes.io/component: "odoo-queue"
     spec:
       serviceAccountName: {{ .Values.serviceAccountName }}
       {{- with .Values.imagePullSecrets }}
@@ -92,7 +91,6 @@ spec:
           readinessProbe:
               {{- toYaml . | nindent 14 }}
           {{- end }}
-
           {{- with .Values.odoo.queuejob.startupProbe }}
           startupProbe:
               {{- toYaml . | nindent 14 }}
@@ -185,10 +183,10 @@ spec:
       targetPort: http
   selector:
     {{- include "odoo.selectorLabels" . | nindent 4 }}
-    {{ if eq .Values.odoo.mode "hybrid" }}
+    {{- if eq .Values.odoo.mode "hybrid" }}
     app.kubernetes.io/component: "odoo-thread"
-    {{ else if eq .Values.odoo.mode "workers" }}
+    {{- else if eq .Values.odoo.mode "workers" }}
     app.kubernetes.io/component: "odoo-worker"
-    {{ end }}
+    {{- end }}
 
 ---

--- a/odoo/templates/networkPolicies.yaml
+++ b/odoo/templates/networkPolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "odoo.name" . }}
-  namespace: 
+  namespace:
 spec:
   ingress:
   - from:


### PR DESCRIPTION
Minor, mostly cosmetic fixes:
- pass current scope `$` to `{{- include "odoo.labels" $ | nindent 4 }}` instead of global scope `.`
  (consistent with what is done for `"odoo.labels"` everywhere)
- remove `include "odoo.selectorLabels" ...` when it is already part of `include "odoo.labels" ...`
- align indentation