### PR TITLE
feat: normalize threaded default memory limits

### DIFF
--- a/odoo/templates/_quotas_thread_helpers.tpl
+++ b/odoo/templates/_quotas_thread_helpers.tpl
@@ -1,16 +1,29 @@
+{{/*
+  The hard limit matches the pod's memory limit (see below), rounded to
+  1 decimal GiB, and the soft limit is always set to 85% of the hard limit
+  (rounded down).
+
+    +-----------+----------------------------+-------------------------------+
+    | type      | hard                       | soft (85% of hard)            |
+    +-----------+----------------------------+-------------------------------+
+    | xlarge    | 2.0 GiB (2147483648 bytes) | 1.700 GiB (1825361100 bytes)  |
+    | large     | 1.5 GiB (1610612736 bytes) | 1.275 GiB (1369020825 bytes)  |
+    | standard  | 1.2 GiB (1288490188 bytes) | 1.020 GiB (1095216659 bytes)  |
+    +-----------+----------------------------+-------------------------------+
+*/}}
 {{- define "odoo.internal-resources-thread" -}}
   {{- if (eq .instance_type "xlarge") }}
-LIMIT_MEMORY_SOFT: {{ .override.memory_soft | default "1610612736" | quote }}
-LIMIT_MEMORY_HARD: {{ .override.memory_hard | default "2097152000" | quote }}
+LIMIT_MEMORY_SOFT: {{ .override.memory_soft | default "1825361100" | quote }}
+LIMIT_MEMORY_HARD: {{ .override.memory_hard | default "2147483648" | quote }}
 WORKERS: "0"
   {{- else if (eq .instance_type "large") }}
 WORKERS: "0"
-LIMIT_MEMORY_SOFT: {{ .override.memory_soft | default "1073741824" | quote }}
+LIMIT_MEMORY_SOFT: {{ .override.memory_soft | default "1369020825" | quote }}
 LIMIT_MEMORY_HARD: {{ .override.memory_hard | default "1610612736" | quote }}
   {{- else}}
 WORKERS: "0"
-LIMIT_MEMORY_SOFT: {{ .override.memory_soft | default "750117120" | quote }}
-LIMIT_MEMORY_HARD: {{ .override.memory_hard | default "943718400" | quote }}
+LIMIT_MEMORY_SOFT: {{ .override.memory_soft | default "1095216659" | quote }}
+LIMIT_MEMORY_HARD: {{ .override.memory_hard | default "1288490188" | quote }}
   {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
Normalizes the default memory limits in `odoo.internal-resources-thread`:

- Round hard limits to 1 decimal GiB, they were inconsistently decimal based (xlarge was 2000 MiB, standard 900 MiB).
- Raise the standard hard limit to 1.2 GiB, so it matches the pod memory limit like the other instance types already did.
- Raise and normalize soft limits to ~85% of hard, they ranged from 67% to 79%.

| type | hard | soft (85% of hard) |
| --- | --- | --- |
| xlarge | 2.0 GiB (2147483648) | 1.700 GiB (1825361100) |
| large | 1.5 GiB (1610612736) | 1.275 GiB (1369020825) |
| standard | 1.2 GiB (1288490188) | 1.020 GiB (1095216659) |
